### PR TITLE
Hotfix/renamed urls on install screen

### DIFF
--- a/frontend/src/app/components/applications/install-screen-dialog/install-screen-dialog.component.html
+++ b/frontend/src/app/components/applications/install-screen-dialog/install-screen-dialog.component.html
@@ -37,7 +37,7 @@
     </div>
 
     <div class="app-install-overlay__body-entry">
-      <span class="app-install-overlay__body-entry-label"> Github URL </span><br/>
+      <span class="app-install-overlay__body-entry-label"> Application URL </span><br/>
       <span class="app-install-overlay__body-entry-description">
         <a href="{{appInfo.application_url}}" target="_blank" rel="noopener noreferrer">
           {{appInfo.application_url}}
@@ -55,7 +55,7 @@
 <!--    </div>-->
 
     <div class="app-install-overlay__body-entry">
-      <span class="app-install-overlay__body-entry-label"> Application URL </span><br/>
+      <span class="app-install-overlay__body-entry-label"> Documentation URL </span><br/>
       <span class="app-install-overlay__body-entry-description">
         <a href="{{appInfo.application_documentation_url}}" target="_blank" rel="noopener noreferrer">
           {{appInfo.application_documentation_url}}


### PR DESCRIPTION
renamed urls on install screen to be complient with the naming in the appinfo.json of the individual apps